### PR TITLE
URL instead of regex

### DIFF
--- a/options.html
+++ b/options.html
@@ -34,7 +34,7 @@
     <div class="container">
         <h1>Link Modifier Options</h1>
         <div class="input-group mb-3">
-            <input type="text" id="regex-input" class="form-control" placeholder="Enter regex pattern">
+            <input type="text" id="regex-input" class="form-control" placeholder="Enter URL">
             <button id="add-regex" class="btn btn-primary">Add</button>
         </div>
         <div id="regex-list" class="list-group"></div>

--- a/options.js
+++ b/options.js
@@ -77,9 +77,19 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   };
 
+  const urlToRegex = (url) => {
+    const formattedUrl = url.replace(/^(https?:\/\/)?(www\.)?/, '').replace(/\/$/, '');
+
+    const domain = formattedUrl.split('/')[0];
+    const domainRegex = `\\.${domain.replace(/\./g, '\\.')}`;
+
+    return domainRegex;
+  };
+
   addRegexButton.addEventListener('click', () => {
-    const regexPattern = regexInput.value.trim();
-    if (regexPattern) {
+    const url = regexInput.value.trim();
+    if (url) {
+      const regexPattern = urlToRegex(url);
       loadRegexList((regexList) => {
         regexList.push({ pattern: regexPattern, active: true });
         saveRegexList(regexList);


### PR DESCRIPTION
A user might not necessarily know regex, so I made changes such that if he enters URL, it will still be accepted and added to the list.
Although the extension is not working locally for me, just made the changes such that it converts URL to regex and append it to the list.